### PR TITLE
Enforce numeric types for geolocation fields

### DIFF
--- a/ckanext/scheming/ckan_dataset.yaml
+++ b/ckanext/scheming/ckan_dataset.yaml
@@ -148,10 +148,12 @@ dataset_fields:
             label: Other      
         
   - field_name: originalDataProjectTimeStart
-    label: Year of original project data collection start   
+    label: Year of original project data collection start
+    validators: ignore_missing int_validator
 
   - field_name: originalDataProjectTimeEnd
-    label: Year of original project data collection end      
+    label: Year of original project data collection end
+    validators: ignore_missing int_validator
 
   - field_name: publisher
     label: Publisher
@@ -348,21 +350,27 @@ dataset_fields:
     
     field_name: geoLocationPointLongitude
     label: Geo Location Point Longitude
+    validators: ignore_missing float_validator
 
   - field_name: geoLocationPointLatitude
     label: Geo Location Point Latitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxWestBoundLongitude
     label: Geo Location Box West Bound Longitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxEastBoundLongitude
-    label: Geo Location Box East Bound Longitude    
-    
+    label: Geo Location Box East Bound Longitude
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxSouthBoundLatitude
     label: Geo Location Box South Bound Latitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxNorthBoundLatitude
-    label: Geo Location Box North Bound Latitude       
+    label: Geo Location Box North Bound Latitude
+    validators: ignore_missing float_validator
                    
   - field_name: FeatureTypes
     label: Feature Type(s)


### PR DESCRIPTION
## Summary
- enforce integer validation for `originalDataProjectTimeStart` and `originalDataProjectTimeEnd`
- enforce floating point validation on all geolocation fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ckan')*

------
https://chatgpt.com/codex/tasks/task_e_686635e4299c83288886efd1915093e3