### PR TITLE
Add float validator and enforce numeric input

### DIFF
--- a/ckanext/scheming/ckan_dataset.yaml
+++ b/ckanext/scheming/ckan_dataset.yaml
@@ -148,10 +148,12 @@ dataset_fields:
             label: Other      
         
   - field_name: originalDataProjectTimeStart
-    label: Year of original project data collection start   
+    label: Year of original project data collection start
+    validators: ignore_missing int_validator
 
   - field_name: originalDataProjectTimeEnd
-    label: Year of original project data collection end      
+    label: Year of original project data collection end
+    validators: ignore_missing int_validator
 
   - field_name: publisher
     label: Publisher
@@ -348,21 +350,27 @@ dataset_fields:
     
     field_name: geoLocationPointLongitude
     label: Geo Location Point Longitude
+    validators: ignore_missing float_validator
 
   - field_name: geoLocationPointLatitude
     label: Geo Location Point Latitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxWestBoundLongitude
     label: Geo Location Box West Bound Longitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxEastBoundLongitude
-    label: Geo Location Box East Bound Longitude    
-    
+    label: Geo Location Box East Bound Longitude
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxSouthBoundLatitude
     label: Geo Location Box South Bound Latitude
-    
+    validators: ignore_missing float_validator
+
   - field_name: geoLocationBoxNorthBoundLatitude
-    label: Geo Location Box North Bound Latitude       
+    label: Geo Location Box North Bound Latitude
+    validators: ignore_missing float_validator
                    
   - field_name: FeatureTypes
     label: Feature Type(s)

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -59,6 +59,19 @@ def strip_value(value):
     return value.strip()
 
 
+@register_validator
+def float_validator(value, context):
+    """Convert value to float if possible."""
+    if value is None or value is missing:
+        return None
+    if hasattr(value, 'strip') and not value.strip():
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise Invalid(_('Invalid number'))
+
+
 @scheming_validator
 @register_validator
 def scheming_choices(field, schema):


### PR DESCRIPTION
## Summary
- add `float_validator` to handle decimal inputs
- enforce integer values for `originalDataProjectTimeStart` and `originalDataProjectTimeEnd`
- apply `float_validator` to geolocation fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686635e4299c83288886efd1915093e3